### PR TITLE
feat: Implement enhanced fretboard highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,43 +13,78 @@
   <div id="root"></div>
   
   <script type="text/babel">
-    function Fretboard({ strings = 6, frets = 5 }) {
-      const notes = ['E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B', 'C', 'C#', 'D', 'D#'];
-      
+    const NOTES = ['E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B', 'C', 'C#', 'D', 'D#'];
+
+    function normalizeNote(noteString) {
+      if (!noteString) {
+        return noteString;
+      }
+      const flatToSharpMap = {
+        'G♭': 'F#', 'A♭': 'G#', 'B♭': 'A#',
+        'D♭': 'C#', 'E♭': 'D#',
+        'C♭': 'B', 'F♭': 'E'
+      };
+      return flatToSharpMap[noteString] || noteString;
+    }
+
+    function getChordNotes(rootNote, chordType = 'major') {
+      rootNote = normalizeNote(rootNote); // Normalize at the beginning
+      if (!rootNote) {
+        return [];
+      }
+      const rootIndex = NOTES.indexOf(rootNote);
+      if (rootIndex === -1) {
+        // If rootNote is still not found after normalization, it's not in our NOTES array
+        return [];
+      }
+
+      if (chordType === 'major') {
+        const majorThird = NOTES[(rootIndex + 4) % 12];
+        const perfectFifth = NOTES[(rootIndex + 7) % 12];
+        return [rootNote, majorThird, perfectFifth];
+      }
+      // Placeholder for other chord types
+      return [];
+    }
+
+    function Fretboard({ strings = 6, frets = 5, selectedCellValue: propSelectedCellValue }) {
       const getNote = (string, fret) => {
         const openNotes = ['E', 'A', 'D', 'G', 'B', 'E'];
         const openNote = openNotes[string];
-        const noteIndex = (notes.indexOf(openNote) + fret) % 12;
-        return notes[noteIndex];
+        const noteIndex = (NOTES.indexOf(openNote) + fret) % 12;
+        return NOTES[noteIndex];
       };
+
+      const normalizedSelectedCellValue = normalizeNote(propSelectedCellValue);
+      const chordNotesArray = propSelectedCellValue ? getChordNotes(normalizedSelectedCellValue, 'major') : [];
 
       return (
         <div className="fretboard">
           {Array.from({ length: strings }).map((_, string) => (
             <div key={string} className="string">
-              {Array.from({ length: frets + 1 }).map((_, fret) => (
-                <div key={fret} className="fret">
-                  <div className="note">{getNote(string, fret)}</div>
-                </div>
-              ))}
+              {Array.from({ length: frets + 1 }).map((_, fret) => {
+                const currentNoteValue = getNote(string, fret);
+                let noteClasses = "note";
+                if (currentNoteValue === normalizedSelectedCellValue && propSelectedCellValue) { // ensure propSelectedCellValue is not null
+                  noteClasses += " selected-root-note";
+                } else if (chordNotesArray.includes(currentNoteValue) && propSelectedCellValue) { // ensure propSelectedCellValue is not null
+                  noteClasses += " chord-interval-note";
+                }
+                return (
+                  <div key={fret} className="fret">
+                    <div className={noteClasses}>{currentNoteValue}</div>
+                  </div>
+                );
+              })}
             </div>
           ))}
         </div>
       );
     }
 
-    function CsvTable() {
+    function CsvTable({ selectedCellValue, selectCell }) {
       const [headers, setHeaders] = React.useState([]);
       const [rows, setRows] = React.useState([]);
-      const [selectedCellValue, setSelectedCellValue] = React.useState(null);
-
-      const selectCell = (value) => {
-        if (selectedCellValue === value) {
-          setSelectedCellValue(null);
-        } else {
-          setSelectedCellValue(value);
-        }
-      };
 
       React.useEffect(() => {
         fetch('/static/data.csv')
@@ -97,14 +132,33 @@
       );
     }
 
-    function App() {
-      return (
-        <div className="app">
-          <h1>Guitar Fretboard Notes</h1>
-          <CsvTable />
-          <Fretboard strings={6} frets={12} />
-        </div>
-      );
+    class App extends React.Component {
+      constructor(props) {
+        super(props);
+        this.state = {
+          selectedCellValue: null, // This will store the original value from the CSV
+        };
+        this.selectCell = this.selectCell.bind(this);
+      }
+
+      selectCell(value) {
+        // The value from the CSV cell, potentially un-normalized
+        this.setState(prevState => ({
+          selectedCellValue: prevState.selectedCellValue === value ? null : value,
+        }));
+      }
+
+      render() {
+        // Pass the original selectedCellValue to CsvTable and Fretboard
+        // Fretboard will handle normalization for its display logic
+        return (
+          <div className="app">
+            <h1>Guitar Fretboard Notes</h1>
+            <CsvTable selectedCellValue={this.state.selectedCellValue} selectCell={this.selectCell} />
+            <Fretboard strings={6} frets={12} selectedCellValue={this.state.selectedCellValue} />
+          </div>
+        );
+      }
     }
     
     const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -93,3 +93,15 @@ th {
 .csv-table td.selected {
   background-color: yellow;
 }
+
+/* Added for selected note highlighting on fretboard */
+.note.selected-root-note {
+  background-color: #ffcc00; /* Bright yellow/orange */
+  color: #000; /* Black text for better contrast on yellow */
+}
+
+/* Added for chord interval note highlighting on fretboard */
+.note.chord-interval-note {
+  background-color: #66ccff; /* Light blue */
+  color: #000; /* Black text for better contrast */
+}


### PR DESCRIPTION
This commit introduces several enhancements to the fretboard and table interaction:

1.  **Selected Note Highlighting**: When a note cell is selected in the table, all instances of that note on the fretboard are highlighted with a distinct style (yellow/orange background).

2.  **Chord Highlighting**: For the selected root note, its corresponding major chord notes (root, major third, perfect fifth) are also highlighted on the fretboard. The interval notes have a different style (light blue background) to distinguish them from the root note.

3.  **State Management Refactor**: The `selectedCellValue` state and its update logic were lifted from the `CsvTable` component to the parent `App` component. This allows sharing the selected note information with both the `CsvTable` (for table cell highlighting) and the `Fretboard` (for note and chord highlighting).

4.  **Note Normalization**: A `normalizeNote` function was added to ensure consistent note representation. Notes from the input CSV data that use flat notation (e.g., "G♭") are converted to their sharp or natural equivalents (e.g., "F#") used by the fretboard logic. This allows correct matching and highlighting regardless of the input notation.

The changes address the issue of highlighting the selected cell's notes and its corresponding musical chord notes on the fretboard.